### PR TITLE
Fix bug in Borrow logic

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -19,6 +19,7 @@ public class Messages {
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
     public static final String MESSAGE_EMPTY_BOOKLIST_FIELD = "Person is currently not borrowing any books!";
+    public static final String MESSAGE_FILLED_BOOKLIST_FIELD = "Person has reached his maximum borrowing limit!";
 
     /**
      * Returns an error message indicating the duplicate prefixes.

--- a/src/main/java/seedu/address/logic/commands/BorrowCommand.java
+++ b/src/main/java/seedu/address/logic/commands/BorrowCommand.java
@@ -55,6 +55,11 @@ public class BorrowCommand extends Command {
         }
 
         Person personToEdit = lastShownList.get(index.getZeroBased());
+
+        if (!personToEdit.getBook().toString().isEmpty()) {
+            throw new CommandException(Messages.MESSAGE_FILLED_BOOKLIST_FIELD);
+        }
+
         Person editedPerson = new Person(personToEdit.getName(), personToEdit.getPhone(), personToEdit.getEmail(),
                 personToEdit.getAddress(), personToEdit.getMeritScore().decrementScore(),
                 bookTitle, personToEdit.getTags());


### PR DESCRIPTION
Added a check to ensure that borrower can only borrow a book if he or she is not borrowing a book already.

Closes #68 .