### PR TITLE
Fixes Prefix b/ bug

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddBookCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddBookCommandParser.java
@@ -25,6 +25,7 @@ public class AddBookCommandParser implements Parser<AddBookCommand> {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_BOOKLIST);
 
         String bookTitle;
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_BOOKLIST);
         try {
             bookTitle = argMultimap.getValue(PREFIX_BOOKLIST).get();
         } catch (NoSuchElementException nee) {

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -40,7 +40,7 @@ public class ArgumentMultimap {
      */
     public Optional<String> getValue(Prefix prefix) {
         List<String> values = getAllValues(prefix);
-        return values.isEmpty() ? Optional.empty() : Optional.of(values.get(0));
+        return values.isEmpty() ? Optional.empty() : Optional.of(values.get(values.size() - 1));
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -40,7 +40,7 @@ public class ArgumentMultimap {
      */
     public Optional<String> getValue(Prefix prefix) {
         List<String> values = getAllValues(prefix);
-        return values.isEmpty() ? Optional.empty() : Optional.of(values.get(values.size() - 1));
+        return values.isEmpty() ? Optional.empty() : Optional.of(values.get(0));
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/BorrowCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/BorrowCommandParser.java
@@ -28,6 +28,7 @@ public class BorrowCommandParser implements Parser<BorrowCommand> {
 
         Index index;
         String bookTitle;
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_BOOKLIST);
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
             bookTitle = argMultimap.getValue(PREFIX_BOOKLIST).get();

--- a/src/main/java/seedu/address/logic/parser/DeleteBookCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteBookCommandParser.java
@@ -25,6 +25,7 @@ public class DeleteBookCommandParser implements Parser<DeleteBookCommand> {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_BOOKLIST);
 
         String bookTitle;
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_BOOKLIST);
         try {
             bookTitle = argMultimap.getValue(PREFIX_BOOKLIST).get();
         } catch (NoSuchElementException nee) {

--- a/src/main/java/seedu/address/logic/parser/DonateCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DonateCommandParser.java
@@ -28,6 +28,7 @@ public class DonateCommandParser implements Parser<DonateCommand> {
 
         Index index;
         String bookTitle;
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_BOOKLIST);
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
             bookTitle = argMultimap.getValue(PREFIX_BOOKLIST).get();

--- a/src/main/java/seedu/address/logic/parser/ReturnCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ReturnCommandParser.java
@@ -29,6 +29,7 @@ public class ReturnCommandParser implements Parser<ReturnCommand> {
 
         Index index;
         String bookTitle;
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_BOOKLIST);
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
             bookTitle = argMultimap.getValue(PREFIX_BOOKLIST).get();


### PR DESCRIPTION
closes #263 

When multiple b/ prefix was added to command, the last prefix was the only input that was utilised. 

What I changed was to add argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_BOOKLIST) to prevent multiple b/ prefix from being used in the command.

Now, there will be an error input to inform user that multiple b/ prefix cannot be used in the same input.