### PR TITLE
Fix all JsonAdaptedTest

### DIFF
--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -6,7 +6,7 @@
     "email" : "alice@example.com",
     "address" : "123, Jurong West Ave 6, #08-111",
     "meritScore": "0",
-    "bookTitle" : "",
+    "bookList" : [ ],
     "tags" : [ "friends" ]
   }, {
     "name" : "Benson Meier",
@@ -14,7 +14,7 @@
     "email" : "johnd@example.com",
     "address" : "311, Clementi Ave 2, #02-25",
     "meritScore": "1",
-    "bookTitle" : "",
+    "bookList" : [ "Valid" ],
     "tags" : [ "owesMoney", "friends" ]
   }, {
     "name" : "Carl Kurz",
@@ -22,7 +22,7 @@
     "email" : "heinz@example.com",
     "address" : "wall street",
     "meritScore": "1",
-    "bookTitle" : "",
+    "bookList" : [ ],
     "tags" : [ ]
   }, {
     "name" : "Daniel Meier",
@@ -30,7 +30,7 @@
     "email" : "cornelia@example.com",
     "address" : "10th street",
     "meritScore": "1",
-    "bookTitle" : "",
+    "bookList" : [ ],
     "tags" : [ "friends" ]
   }, {
     "name" : "Elle Meyer",
@@ -38,7 +38,7 @@
     "email" : "werner@example.com",
     "address" : "michegan ave",
     "meritScore": "1",
-    "bookTitle" : "",
+    "bookList" : [ ],
     "tags" : [ ]
   }, {
     "name" : "Fiona Kunz",
@@ -46,7 +46,7 @@
     "email" : "lydia@example.com",
     "address" : "little tokyo",
     "meritScore": "1",
-    "bookTitle" : "",
+    "bookList" : [ ],
     "tags" : [ ]
   }, {
     "name" : "George Best",
@@ -54,15 +54,15 @@
     "email" : "anna@example.com",
     "address" : "4th street",
     "meritScore": "1",
-    "bookTitle" : "",
+    "bookList" : [ ],
     "tags" : [ ]
   }, {
     "name" : "Jacker",
     "phone" : "87173548",
     "email" : "jacker@hotmail.com",
     "address" : "420, Curry Tasty, #69-420",
-    "meritScore": "-1",
-    "bookTitle" : "How To Grow Taller",
+    "meritScore": "1",
+    "bookList" : [ ],
     "tags" : [ "friends" ]
   }, {
     "name" : "Kepler",
@@ -70,7 +70,15 @@
     "email" : "kepler@hotmail.com",
     "address" : "54, Stuttgart, #12-23",
     "meritScore": "1",
-    "bookTitle" : "How To Become a Better Reader?",
+    "bookList" : [ "How To Become a Better Reader?" ],
     "tags" : [ "teachers" ]
+  }, {
+    "name" : "Joe Meme",
+    "phone" : "89899898",
+    "email" : "joe@gmail.com",
+    "address" : "123A, King's Street, #13-5",
+    "meritScore": "-100",
+    "bookList" : [ ],
+    "tags" : [ "LowMerit" ]
   }]
 }

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -154,13 +154,13 @@ public class JsonAdaptedPersonTest {
 
     @Test
     public void toModelType_nullBookList_returnsPerson() throws Exception {
-        Person BensonWithNoBook = new Person(BENSON.getName(), BENSON.getPhone(), BENSON.getEmail(),
+        Person bensonWithNoBook = new Person(BENSON.getName(), BENSON.getPhone(), BENSON.getEmail(),
                 BENSON.getAddress(), BENSON.getMeritScore(), new ArrayList<>(), BENSON.getTags());
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_MERIT_SCORE,
                         null, VALID_TAGS);
 
-        assertEquals(BensonWithNoBook, person.toModelType());
+        assertEquals(bensonWithNoBook, person.toModelType());
     }
 
     @Test

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -1,9 +1,10 @@
-/*package seedu.address.storage;
+package seedu.address.storage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.storage.JsonAdaptedPerson.MISSING_FIELD_MESSAGE_FORMAT;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.BENSON;
+import static seedu.address.testutil.TypicalPersons.BOB;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -18,6 +19,7 @@ import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.MeritScore;
 import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 
 public class JsonAdaptedPersonTest {
@@ -27,7 +29,7 @@ public class JsonAdaptedPersonTest {
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_MERIT_SCORE = "abc";
     private static final ArrayList<JsonAdaptedBook> INVALID_BOOK_LIST =
-            new ArrayList<>(Arrays.asList(new Book(" title")))
+            new ArrayList<>(Arrays.asList("  title  "))
                     .stream()
                     .map(JsonAdaptedBook::new)
                     .collect(Collectors.toCollection(ArrayList::new));;
@@ -152,12 +154,14 @@ public class JsonAdaptedPersonTest {
     }
 
     @Test
-    public void toModelType_nullBookList_throwsIllegalValueException() {
+    public void toModelType_nullBookList_returnsPerson() throws Exception {
+        Person BensonWithNoBook = new Person(BENSON.getName(), BENSON.getPhone(), BENSON.getEmail(),
+                BENSON.getAddress(), BENSON.getMeritScore(), new ArrayList<>(), BENSON.getTags());
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_MERIT_SCORE,
                         null, VALID_TAGS);
-        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Book.class.getSimpleName());
-        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+
+        assertEquals(BensonWithNoBook, person.toModelType());
     }
 
     @Test
@@ -170,4 +174,4 @@ public class JsonAdaptedPersonTest {
         assertThrows(IllegalValueException.class, person::toModelType);
     }
 
-}*/
+}

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.storage.JsonAdaptedPerson.MISSING_FIELD_MESSAGE_FORMAT;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.BENSON;
-import static seedu.address.testutil.TypicalPersons.BOB;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/test/java/seedu/address/storage/JsonSerializableAddressBookTest.java
+++ b/src/test/java/seedu/address/storage/JsonSerializableAddressBookTest.java
@@ -1,6 +1,6 @@
 package seedu.address.storage;
 
-//import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import java.nio.file.Path;
@@ -10,8 +10,8 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.commons.util.JsonUtil;
-//import seedu.address.model.AddressBook;
-//import seedu.address.testutil.TypicalPersons;
+import seedu.address.model.AddressBook;
+import seedu.address.testutil.TypicalPersons;
 
 public class JsonSerializableAddressBookTest {
 
@@ -20,14 +20,14 @@ public class JsonSerializableAddressBookTest {
     private static final Path INVALID_PERSON_FILE = TEST_DATA_FOLDER.resolve("invalidPersonAddressBook.json");
     private static final Path DUPLICATE_PERSON_FILE = TEST_DATA_FOLDER.resolve("duplicatePersonAddressBook.json");
 
-    /*@Test
+    @Test
     public void toModelType_typicalPersonsFile_success() throws Exception {
         JsonSerializableAddressBook dataFromFile = JsonUtil.readJsonFile(TYPICAL_PERSONS_FILE,
                 JsonSerializableAddressBook.class).get();
         AddressBook addressBookFromFile = dataFromFile.toModelType();
         AddressBook typicalPersonsAddressBook = TypicalPersons.getTypicalAddressBook();
         assertEquals(addressBookFromFile, typicalPersonsAddressBook);
-    }*/
+    }
 
     @Test
     public void toModelType_invalidPersonFile_throwsIllegalValueException() throws Exception {


### PR DESCRIPTION
Changed the format of the typicalPersonAddressBook so that can pass all JsonAdapted test case

As a person can build with a null book list, so the test case:
`toModelType_nullBookList_throwsIllegalValueException()` changed to `toModelType_nullBookList_returnsPerson()`