### PR TITLE
Fix DeleteBookCommand tests

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteBookCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteBookCommand.java
@@ -68,7 +68,7 @@ public class DeleteBookCommand extends Command {
         }
 
         // instanceof handles nulls
-        if (!(other instanceof DeleteCommand)) {
+        if (!(other instanceof DeleteBookCommand)) {
             return false;
         }
 

--- a/src/test/java/seedu/address/logic/commands/DeleteBookCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteBookCommandTest.java
@@ -73,9 +73,8 @@ public class DeleteBookCommandTest {
         assertTrue(deleteBookCommand1.equals(deleteBookCommand1));
 
         // same values -> returns true
-        // For some reason, this does not pass
-        // DeleteBookCommand deleteBookCommand1Copy = new DeleteBookCommand(bookStub1);
-        // assertTrue(deleteBookCommand1.equals(deleteBookCommand1Copy));
+        DeleteBookCommand deleteBookCommand1Copy = new DeleteBookCommand(bookStub1);
+        assertTrue(deleteBookCommand1.equals(deleteBookCommand1Copy));
 
         // different types -> returns false
         assertFalse(deleteBookCommand1.equals(1));

--- a/src/test/java/seedu/address/logic/parser/DeleteBookCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteBookCommandParserTest.java
@@ -2,12 +2,14 @@ package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 //import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.DeleteBookCommand;
 //import seedu.address.model.book.Book;
+import seedu.address.model.book.Book;
 
 
 public class DeleteBookCommandParserTest {
@@ -40,7 +42,7 @@ public class DeleteBookCommandParserTest {
         assertParseFailure(parser, "i/ string", MESSAGE_INVALID_FORMAT);
     }
 
-    /*@Test
+    @Test
     public void parse_allFieldsPresent_success() {
         // book title with no space in front and at back
         assertParseSuccess(parser, " " + CliSyntax.PREFIX_BOOKLIST + BOOK_TITLE_STUB,
@@ -49,5 +51,5 @@ public class DeleteBookCommandParserTest {
         // book title with spaces in front and at back
         assertParseSuccess(parser, " " + CliSyntax.PREFIX_BOOKLIST + "    " + BOOK_TITLE_STUB + "    ",
                 new DeleteBookCommand(new Book(BOOK_TITLE_STUB)));
-    }*/
+    }
 }


### PR DESCRIPTION
Fixed DeleteBookCommandTest
Fixed DeleteBookCommandParserTest
closes #295 

Changed DeleteBookCommand.java
Changed line 71
Changed DeleteCommand to DeleteBookCommand in line 71.
Changed to allow DeleteBookCommandTest and DeleteBookCommandParserTest to pass.